### PR TITLE
stop trying to check if audio is supported

### DIFF
--- a/jquery.toasty.js
+++ b/jquery.toasty.js
@@ -25,11 +25,6 @@
         return this.each(function() {
 
       var _this = $(this);
-      var audioSupported = false;
-      //Stupid Browser Checking which should be in jQuery Support
-      if ($.browser.mozilla && $.browser.version.substr(0, 5) >= "1.9.2" || $.browser.webkit) { 
-        audioSupported = true;
-      }
       
       //Toasty Vars
       var toastyImageMarkup = '<img id="elDan" style="display: none" src="toasty.png" />'
@@ -38,7 +33,7 @@
       
       //Append Toasty and Style
       $('body').append(toastyImageMarkup);
-      if(audioSupported) { $('body').append(toastyAudioMarkup); }
+      $('body').append(toastyAudioMarkup);
       var DanForden = $('#elDan').css({
         "position":"fixed",
         "bottom": "0",
@@ -50,12 +45,7 @@
       function init() {
       
         //Sound Hilarity
-        if(audioSupported) { 
-          function playSound() {
-            document.getElementById('Toasty!').play();
-          }
-          playSound();
-        }
+        document.getElementById('Toasty!').play();
                 
         // Movement Hilarity  
         DanForden.animate({


### PR DESCRIPTION
Someone actually emailed me about the audio not working:

> Hi,
> I have a problem with your code when i set with timerdelay. I have no sound!
> I use a google chrome browser and i set audioSupported = true in .js files. All works when i use a Click me to activate the Toasty! plugin.
> 
> Do you have a solution?
> Thanks

So the browser detection stuff for audio was definitely busted at some point. I just removed it altogether.

As to why audio doesn't work in the timer version, that's new autoplay policy by the Chromium team: `Uncaught (in promise) DOMException: play() failed because the user didn't interact with the document first. https://goo.gl/xX8pDD`

Nothing to be done about that as it's just good policy not to autoplay video/audio before users interact with a page. Assuming you set a sufficient timer length (say 30s - 60s) and users click somewhere on the page before the timer finishes you'll still get audio to play.